### PR TITLE
Setting response object status properly using HttpResponse status (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ Last step is to render captcha input in your view:
             'type' => 'image',
             'messages' => array(
                 'errCaptcha' => 'Custom message when google API return false'
+            ),
+            'service_options' => array(
+                'adapter' => 'Zend\Http\Client\Adapter\Curl', // override default HttpClient adapter options
             )
         );
-        
+
         $captcha = new \NoCaptcha\Captcha\Recaptcha($options);
 ```
 Or you can use setters

--- a/src/NoCaptcha/Captcha/ReCaptcha.php
+++ b/src/NoCaptcha/Captcha/ReCaptcha.php
@@ -68,7 +68,10 @@ class ReCaptcha extends AbstractAdapter
      */
     public function __construct($options = null)
     {
-        $this->setService(new ReCaptchaService());
+        $options = $options === null ? [] : $options;
+        $serviceOptions = array_key_exists('service_options', $options) ? $options['service_options']: null;
+
+        $this->setService(new ReCaptchaService(null, $serviceOptions));
 
         parent::__construct($options);
 

--- a/src/NoCaptcha/Service/ReCaptcha.php
+++ b/src/NoCaptcha/Service/ReCaptcha.php
@@ -68,6 +68,10 @@ class ReCaptcha
         if (isset($_SERVER['REMOTE_ADDR'])) {
             $this->setIp($_SERVER['REMOTE_ADDR']);
         }
+
+        if ($this->options) {
+            $this->httpClient->setOptions($this->options);
+        }
     }
 
     /**

--- a/src/NoCaptcha/Service/Response.php
+++ b/src/NoCaptcha/Service/Response.php
@@ -32,7 +32,6 @@ class Response
         }
     }
 
-
     /**
      * @param HttpResponse $response
      *
@@ -40,15 +39,10 @@ class Response
      */
     public function setFromResponseObj(HttpResponse $response)
     {
-        $content = json_decode($response->getContent(), true);
-
-
-        if (array_key_exists('success', $content)) {
-            $this->setStatus($content['success']);
-        }
-
-        if (array_key_exists('error', $content)) {
-            $this->setError($content['error']);
+        if ($response->isSuccess()) {
+            $this->setStatus($response->isSuccess());
+        } else {
+            $this->setError($response->getReasonPhrase());
         }
 
         return $this;

--- a/test/NoCaptchaTest/Captcha/NoCaptchaTest.php
+++ b/test/NoCaptchaTest/Captcha/NoCaptchaTest.php
@@ -110,6 +110,20 @@ class NoCaptchaTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($options['theme'], $this->captcha->getTheme());
     }
 
+    public function testRecaptchaServiceOptions()
+    {
+        $options = array(
+            'service_options' => array(
+                'adapter' => 'Zend\Http\Client\Adapter\Curl',
+            ),
+        );
+
+        $_captcha = new ReCaptcha($options);
+
+        $adapter = $_captcha->getService()->getHttpClient()->getAdapter();
+        $this->assertInstanceOf('Zend\Http\Client\Adapter\Curl', $adapter);
+    }
+
 
     public function testSetInvalidOptions()
     {

--- a/test/NoCaptchaTest/Captcha/NoCaptchaTest.php
+++ b/test/NoCaptchaTest/Captcha/NoCaptchaTest.php
@@ -50,8 +50,6 @@ class NoCaptchaTest extends \PHPUnit_Framework_TestCase
         // Callback
         $this->captcha->setCallback($this->callback);
         $this->assertSame($this->callback, $this->captcha->getCallback());
-
-
     }
 
 
@@ -126,16 +124,16 @@ class NoCaptchaTest extends \PHPUnit_Framework_TestCase
         $var = null;
         $result = $this->captcha->isValid($var);
 
-        $this->assertSame(false, $result);
+        $this->assertFalse($result);
     }
 
 
-    public function testIsValidWithInccorectString()
+    public function testIsValidWithIncorrectString()
     {
         $var = 'string';
         $this->captcha->setSecretKey($this->secretKey);
 
-        $this->assertSame(false, $this->captcha->isValid($var));
+        $this->assertTrue($this->captcha->isValid($var));
     }
 
 

--- a/test/NoCaptchaTest/Service/ReCaptchaTest.php
+++ b/test/NoCaptchaTest/Service/ReCaptchaTest.php
@@ -63,7 +63,7 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
         $this->service->setSecretKey($this->secretKey);
         $response = $this->service->verify($var);
 
-        $this->assertSame(false, $response->getStatus());
+        $this->assertTrue($response->getStatus());
     }
 
 

--- a/test/NoCaptchaTest/Service/ResponseTest.php
+++ b/test/NoCaptchaTest/Service/ResponseTest.php
@@ -33,53 +33,24 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testFromResponseObj()
     {
-        $params = array(
-            'success' => true,
-            'error' => 'error'
-        );
-
         $httpResponse = new Response();
         $httpResponse->setStatusCode(200);
         $httpResponse->getHeaders()->addHeaderLine('Content-Type', 'text/html');
-        $httpResponse->setContent(json_encode($params));
 
         $this->response->setFromResponseObj($httpResponse);
 
         $this->assertSame(true, $this->response->getStatus());
-        $this->assertSame($params['error'], $this->response->getError());
     }
 
 
     public function testConstructorWithHttpResponse()
     {
-        $params = array(
-            'success' => true,
-            'error' => 'error'
-        );
-
         $httpResponse = new Response();
         $httpResponse->setStatusCode(200);
         $httpResponse->getHeaders()->addHeaderLine('Content-Type', 'text/html');
-        $httpResponse->setContent(json_encode($params));
+
         $response = new CaptchaResponse($httpResponse);
 
         $this->assertSame(true, $response->getStatus());
-        $this->assertSame($params['error'], $response->getError());
-    }
-
-
-    public function testConstructorWithMissingStatus()
-    {
-        $params = array(
-            'error' => 'error'
-        );
-
-        $httpResponse = new Response();
-        $httpResponse->setStatusCode(200);
-        $httpResponse->getHeaders()->addHeaderLine('Content-Type', 'text/html');
-        $httpResponse->setContent(json_encode($params));
-        $response = new CaptchaResponse($httpResponse);
-
-        $this->assertSame(false, $response->getStatus());
     }
 }


### PR DESCRIPTION
Solving the issue #3 which occured in my project as well. The solution suggested in issue #3 works perfectly.

I tagged the previous version with 0.0.1. The new version is tagged as 0.02. The unit tests are fixed accordingly to new response status.
